### PR TITLE
Convert string UUIDs to CBUUID for advertisement

### DIFF
--- a/src/bleno_mac.mm
+++ b/src/bleno_mac.mm
@@ -69,7 +69,7 @@ Napi::Value BlenoMac::StartAdvertising(const Napi::CallbackInfo& info) {
     ARG2(String, Array);
 
     auto name = napiToString(info[0].As<Napi::String>());
-    NSArray *array = getUuidArray(info[1]);
+    NSArray *array = getCBUuidArray(info[1]);
 
     [peripheralManager startAdvertising:name
                            serviceUUIDs:array];

--- a/src/napi_objc.h
+++ b/src/napi_objc.h
@@ -6,7 +6,10 @@
 #include <map>
 
 NSArray* getUuidArray(const Napi::Value& value);
+NSArray* getCBUuidArray(const Napi::Value& value);
 BOOL getBool(const Napi::Value& value, BOOL def);
+NSArray* napiToCBUuidArray(Napi::Array array);
+CBUUID* napiToCBUuidString(Napi::String string);
 NSArray<CBMutableService *> *napiArrayToCBMutableServices(Napi::Array array);
 CBMutableService *napiToCBMutableService(Napi::Object obj);
 NSArray<CBMutableCharacteristic *> *napiArrayToCBMutableCharacteristics(Napi::Array array);

--- a/src/napi_objc.mm
+++ b/src/napi_objc.mm
@@ -263,3 +263,24 @@ BOOL getBool(const Napi::Value& value, BOOL def) {
     }
     return def;
 }
+
+NSArray* napiToCBUuidArray(Napi::Array array) {
+    NSMutableArray* serviceUuids = [NSMutableArray arrayWithCapacity:array.Length()];
+    for(size_t i = 0;  i < array.Length(); i++) {
+        Napi::Value val = array[i];
+        [serviceUuids addObject:napiToCBUuidString(val.As<Napi::String>())];
+    }
+    return serviceUuids;
+}
+
+CBUUID* napiToCBUuidString(Napi::String string) {
+    NSString* uuidString = napiToUuidString(string);
+    return [CBUUID UUIDWithString:uuidString];
+}
+
+NSArray* getCBUuidArray(const Napi::Value& value) {
+    if (value.IsArray()) {
+        return napiToCBUuidArray(value.As<Napi::Array>());
+    }
+    return nil;
+}


### PR DESCRIPTION
This is to fix https://github.com/notjosh/bleno-mac/issues/4, a bug
which causes the advertising data to not contain the service UUIDs.
This prevents some centrals from being able to properly discover the
peripheral while scanning.